### PR TITLE
Fanilo | remove 'PBX_HMAC' from the array before hmac compute

### DIFF
--- a/packages/paybox-system/src/paybox.ts
+++ b/packages/paybox-system/src/paybox.ts
@@ -126,7 +126,7 @@ export class Paybox implements Document {
     if (this.request.PBX_HMAC) {
       const elements = this.getFormElements()
       const hmac = Buffer.from(this.request.PBX_HMAC, 'hex')
-      const chain = elements.map((e) => `${e.name}=${e.value}`).join('&')
+      const chain = elements.filter(element => element.name !== 'PBX_HMAC')map((e) => `${e.name}=${e.value}`).join('&')
 
       this.request.PBX_HMAC = crypto.createHmac('sha512', hmac).update(chain).digest('hex').toUpperCase()
     }

--- a/packages/paybox-system/src/paybox.ts
+++ b/packages/paybox-system/src/paybox.ts
@@ -126,7 +126,7 @@ export class Paybox implements Document {
     if (this.request.PBX_HMAC) {
       const elements = this.getFormElements()
       const hmac = Buffer.from(this.request.PBX_HMAC, 'hex')
-      const chain = elements.filter(element => element.name !== 'PBX_HMAC')map((e) => `${e.name}=${e.value}`).join('&')
+      const chain = elements.filter(e => e.name !== 'PBX_HMAC').map((e) => `${e.name}=${e.value}`).join('&')
 
       this.request.PBX_HMAC = crypto.createHmac('sha512', hmac).update(chain).digest('hex').toUpperCase()
     }


### PR DESCRIPTION
i'm using the paybox system and i found that it doesn't work when the 'PBX_HMAC' is in the string to be computed for its value.
i fix it 