### PR TITLE
Bump soap from 0.37.0 to 0.39.0 in /packages/vat-number

### DIFF
--- a/packages/vat-number/package.json
+++ b/packages/vat-number/package.json
@@ -26,6 +26,6 @@
     "access": "public"
   },
   "dependencies": {
-    "soap": "^0.37.0"
+    "soap": "^0.39.0"
   }
 }

--- a/packages/vat-number/yarn.lock
+++ b/packages/vat-number/yarn.lock
@@ -304,10 +304,10 @@ sax@>=0.6:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-soap@^0.37.0:
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/soap/-/soap-0.37.0.tgz#19f58cb5978d8b6b5e5bb84fde0d939f211e6f70"
-  integrity sha512-AFVq9EzLcZBoqhi06reLfAyYj6oj0GfBX+yyt7beMW/BdfH8MeL/OhgUabKvpNEqW5vo94VNIHEgN1r8GBH3dQ==
+soap@^0.39.0:
+  version "0.39.0"
+  resolved "https://registry.yarnpkg.com/soap/-/soap-0.39.0.tgz#66f1eebbd93cef39b40623c01eeb434c8898a720"
+  integrity sha512-H1pbwOzc2Q+T2u2OZ/VOGoXKPjjlEELJru6glc1Vi9nZtfxGYRW6teU0W/vavSZ1j404VGCA8TNzWqAm8QI7Xg==
   dependencies:
     debug "^4.1.1"
     get-stream "^6.0.0"


### PR DESCRIPTION
Resolves high severity vulnerability CVE-2021-23358 in transitive dependency underscore.

Fixes #23

Tests still pass after this change:
![Schermafbeelding 2021-06-11 om 23 37 09](https://user-images.githubusercontent.com/618233/121751212-004da000-cb0e-11eb-848d-0c18c8433b3f.png)
